### PR TITLE
Finalize mod class, private proxy, migrate to Mod$InstanceFactory

### DIFF
--- a/src/main/java/xyz/poketech/diy/DyeItYourself.java
+++ b/src/main/java/xyz/poketech/diy/DyeItYourself.java
@@ -13,7 +13,7 @@ import xyz.poketech.diy.proxy.CommonProxy;
 
 @Mod.EventBusSubscriber
 @Mod(modid = DyeItYourself.MODID, name = DyeItYourself.NAME, version = DyeItYourself.VERSION, acceptedMinecraftVersions = DyeItYourself.VERSION_RANGE)
-public class DyeItYourself {
+public final class DyeItYourself {
     public static final String MODID = "diy";
 
     public static final String NAME = "Dye it yourself";
@@ -23,13 +23,19 @@ public class DyeItYourself {
 
     public static final SimpleNetworkWrapper NETWORK = new SimpleNetworkWrapper(MODID);
 
-    @Mod.Instance
-    public static DyeItYourself instance;
+    private static final DyeItYourself INSTANCE = new DyeItYourself();
 
     public static final Logger LOGGER = LogManager.getLogger(MODID);
 
     @SidedProxy(clientSide = "xyz.poketech.diy.proxy.ClientProxy", serverSide = "xyz.poketech.diy.proxy.CommonProxy")
-    public static CommonProxy proxy;
+    private static CommonProxy proxy;
+
+    private DyeItYourself() {}
+
+    @Mod.InstanceFactory
+    public static DyeItYourself getInstance() {
+        return INSTANCE;
+    }
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent e){


### PR DESCRIPTION
- Finalizing classes is good practise for types that you do not intend to have extended. This is especially good practise for singleton classes - see below - that should only ever have one implementation of themselves at compile time and/or runtime.
- Exposing the mutable proxy field is bad practise and design. The proxy in this case is only ever referenced from the mod class itself, so the field has been marked as `private`.
- Migrating to `Mod$InstanceFactory` allows you full control over your mod instance, rather than relying on a reflectively assigned mutable field. This PR suggests an implementation of an eagerly loaded singleton, i.e a `private static final` instance in the root of the class, paired with a `private` constructor.